### PR TITLE
Color each line instead of whole lines

### DIFF
--- a/lib/Mojo/Log/Colored.pm
+++ b/lib/Mojo/Log/Colored.pm
@@ -27,6 +27,8 @@ sub format {
 
     return $self->_format(
         sub {
+            # Prevent having the end escape sequence at the start of the line
+            local $Term::ANSIColor::EACHLINE = "\n";
             # only add colors if we have a color for this level
             exists $self->colors->{ $_[1] }
                 ? colored( $format->(@_), $self->colors->{ $_[1] } )

--- a/t/via_mojo.t
+++ b/t/via_mojo.t
@@ -35,8 +35,8 @@ for my $level ( sort keys %defaults ) {
     like $stderr, qr{
         \Q$defaults{$level}\E   # color of this level, escaped
         $level
-        \n
         \e\[0m                  # end of coloring
+        \n
     }x, "log contains colors for $level";
 }
 done_testing;


### PR DESCRIPTION
Right now, the color-end escape sequence will turn
up after the last linebreak on its own line.

This can actually disturb output, for example when running
tests with prove.

This change will make Term::ANSIColor color each line, without the
linebreaks.